### PR TITLE
Workflow execution extension to multiple resource collections

### DIFF
--- a/src/js/Collections/BaseCollection.js
+++ b/src/js/Collections/BaseCollection.js
@@ -265,6 +265,15 @@ export default class BaseCollection extends Backbone.Collection
         this.fetch({data: this._lastData});
     }
 
+    swapItems(index1, index2)
+    {
+        if (index1 !== index2) {
+            var models = this.models.slice();
+            models[index1] = models.splice(index2, 1, models[index1])[0];
+            this.set(models);
+        }
+    }
+
 ///////////////////////////////////////////////////////////////////////////////////////
 // PRIVATE METHODS
 ///////////////////////////////////////////////////////////////////////////////////////

--- a/src/js/Controllers/ControllerWorkflowBuilder.js
+++ b/src/js/Controllers/ControllerWorkflowBuilder.js
@@ -362,12 +362,6 @@ export default class ControllerWorkflowBuilder extends BaseController
     {
         var url = options.inputport.get('url');
         var resourcesAssigned = this._getResourceAssignments(url);
-        var multipleUrl = this._getInputPortURLWithMultipleAssignments();
-        if (multipleUrl && resourcesAssigned.length > 0 && multipleUrl !== url)
-        {
-            console.error('TODO ERROR');
-            return;
-        }
         resourcesAssigned.add(options.resource);
     }
 
@@ -778,6 +772,7 @@ export default class ControllerWorkflowBuilder extends BaseController
     }
 
     /**
+     * DEPRECATED
      * Return InputPort URL that has multiple assignments.
      * Returns null if DNE.
      */

--- a/src/js/Controllers/ControllerWorkflowBuilder.js
+++ b/src/js/Controllers/ControllerWorkflowBuilder.js
@@ -17,6 +17,7 @@ import ResourceList from 'js/Models/ResourceList';
 import ViewJobCollection from 'js/Views/Master/Main/Job/Collection/ViewJobCollection';
 import ViewResourceCollectionModal from 'js/Views/Master/Main/Resource/Collection/ViewResourceCollectionModal';
 import ViewResourceCollectionModalItem from 'js/Views/Master/Main/Resource/Collection/ViewResourceCollectionModalItem';
+import ViewResourceCollectionModalItemAssigned from 'js/Views/Master/Main/Resource/Collection/ViewResourceCollectionModalItemAssigned';
 import ViewWorkflow from 'js/Views/Master/Main/Workflow/Individual/ViewWorkflow';
 import ViewWorkflowCollection from 'js/Views/Master/Main/Workflow/Collection/ViewWorkflowCollection';
 import ViewWorkflowCollectionImportItem from 'js/Views/Master/Main/Workflow/Collection/ViewWorkflowCollectionImportItem';
@@ -59,6 +60,8 @@ export default class ControllerWorkflowBuilder extends BaseController
         Radio.channel('rodan').reply(RODAN_EVENTS.REQUEST__WORKFLOWBUILDER_ADD_WORKFLOWJOB, options => this._handleRequestAddWorkflowJob(options), this);
         Radio.channel('rodan').reply(RODAN_EVENTS.REQUEST__WORKFLOWBUILDER_ADD_WORKFLOWJOBGROUP, options => this._handleRequestAddWorkflowJobGroup(options), this);
         Radio.channel('rodan').reply(RODAN_EVENTS.REQUEST__WORKFLOWBUILDER_ASSIGN_RESOURCE, options => this._handleRequestAssignResource(options), this);
+        Radio.channel('rodan').reply(RODAN_EVENTS.REQUEST__WORKFLOWBUILDER_ASSIGNED_RESOURCE_MOVE_UP, options => this._handleMoveUpAssignedResource(options), this);
+        Radio.channel('rodan').reply(RODAN_EVENTS.REQUEST__WORKFLOWBUILDER_ASSIGNED_RESOURCE_MOVE_DOWN, options => this._handleMoveDownAssignedResource(options), this);
         Radio.channel('rodan').reply(RODAN_EVENTS.REQUEST__WORKFLOWBUILDER_CREATE_WORKFLOWRUN, options => this._handleRequestCreateWorkflowRun(options), this);
         Radio.channel('rodan').reply(RODAN_EVENTS.REQUEST__WORKFLOWBUILDER_ADD_DISTRIBUTOR, options => this._handleRequestCreateDistributor(options), this);
         Radio.channel('rodan').reply(RODAN_EVENTS.REQUEST__WORKFLOWBUILDER_REMOVE_CONNECTION, options => this._handleRequestDeleteConnection(options), this); 
@@ -180,10 +183,10 @@ export default class ControllerWorkflowBuilder extends BaseController
         var assignedResources = this._getResourceAssignments(inputPort.get('url'));
         var availableResources = this._getResourcesAvailable(inputPort);
         var assignedResourceView = new ViewResourceCollectionModal({collection: assignedResources,
-                                                                    childView: ViewResourceCollectionModalItem,
-                                                                    childViewOptions: {assigned: true, 
-                                                                                       requestdata: {workflow: options.workflow, inputport: inputPort},
-                                                                                       assignrequest: RODAN_EVENTS.REQUEST__WORKFLOWBUILDER_ASSIGN_RESOURCE,
+                                                                    childView: ViewResourceCollectionModalItemAssigned,
+                                                                    childViewOptions: {requestdata: {workflow: options.workflow, inputport: inputPort},
+                                                                                       moveup: RODAN_EVENTS.REQUEST__WORKFLOWBUILDER_ASSIGNED_RESOURCE_MOVE_UP,
+                                                                                       movedown: RODAN_EVENTS.REQUEST__WORKFLOWBUILDER_ASSIGNED_RESOURCE_MOVE_DOWN,
                                                                                        unassignrequest: RODAN_EVENTS.REQUEST__WORKFLOWBUILDER_UNASSIGN_RESOURCE}});
         var resourceListView = new ViewResourceCollectionModal({collection: availableResources,
                                                                 childView: ViewResourceCollectionModalItem,
@@ -372,6 +375,30 @@ export default class ControllerWorkflowBuilder extends BaseController
     {
         var resourcesAssigned = this._getResourceAssignments(options.inputport.get('url'));
         resourcesAssigned.remove(options.resource);
+    }
+
+    /**
+     * Handle the moving up of an assigned resource.
+     */
+    _handleMoveUpAssignedResource(options)
+    {
+        var url = options.inputport.get('url');
+        var resourcesAssigned = this._getResourceAssignments(url);
+        var index1 = resourcesAssigned.indexOf(options.resource);
+        var index2 = Math.max(0, index1 - 1);
+        resourcesAssigned.swapItems(index1, index2);
+    }
+
+    /**
+     * Handle the moving down of an assigned resource.
+     */
+    _handleMoveDownAssignedResource(options)
+    {
+        var url = options.inputport.get('url');
+        var resourcesAssigned = this._getResourceAssignments(url);
+        var index1 = resourcesAssigned.indexOf(options.resource);
+        var index2 = Math.min(index1 + 1, resourcesAssigned.length - 1);
+        resourcesAssigned.swapItems(index1, index2);
     }
 
     /**

--- a/src/js/Shared/RODAN_EVENTS.js
+++ b/src/js/Shared/RODAN_EVENTS.js
@@ -483,6 +483,8 @@ class RODAN_EVENTS
         ///////////////////////////////////////////////////////////////////////////////////////
         /** Triggered when WorkflowRun created. Sends {workflowrun: WorkflowRun}. */
         this.EVENT__WORKFLOWRUN_CREATED = 'EVENT__WORKFLOWRUN_CREATED';
+        /** Triggered when WorkflowRun failed to create. Sends {workflowrun: WorkflowRun, errors: object}. */
+        this.EVENT__WORKFLOWRUN_FAILED_TO_CREATE = 'EVENT__WORKFLOWRUN_FAILED_TO_CREATE';
         /** Triggered when WorkflowRun deleted. Sends {workflowrun: WorkflowRun}. */
         this.EVENT__WORKFLOWRUN_DELETED = 'EVENT__WORKFLOWRUN_DELETED';
         /** Triggered when WorkflowRun saved. Sends {workflowrun: WorkflowRun}. */

--- a/src/js/Shared/RODAN_EVENTS.js
+++ b/src/js/Shared/RODAN_EVENTS.js
@@ -392,6 +392,11 @@ class RODAN_EVENTS
         this.REQUEST__WORKFLOWBUILDER_ADD_WORKFLOWJOBGROUP = 'REQUEST__WORKFLOWBUILDER_ADD_WORKFLOWJOBGROUP';
         /** Request a Resource be assigned to an InputPort. Takes {resource: Resource, inputport: InputPort, workflow: Workflow}. */
         this.REQUEST__WORKFLOWBUILDER_ASSIGN_RESOURCE = 'REQUEST__WORKFLOWBUILDER_ASSIGN_RESOURCE';
+        /** Request an assigned resource to move up. Takes {resource: Resource, inputport: InputPort, workflow: Workflow}. */
+        this.REQUEST__WORKFLOWBUILDER_ASSIGNED_RESOURCE_MOVE_UP = 'REQUEST__WORKFLOWBUILDER_ASSIGNED_RESOURCE_MOVE_UP';
+        /** Request an assigned resource to move down. Takes {resource: Resource, inputport: InputPort, workflow: Workflow}. */
+        this.REQUEST__WORKFLOWBUILDER_ASSIGNED_RESOURCE_MOVE_DOWN = 'REQUEST__WORKFLOWBUILDER_ASSIGNED_RESOURCE_MOVE_DOWN';
+
         /** Request a WorkflowRun be created. The WorkflowBuilder will use the known Resource assignments that have been made. Takes {workflow: Workflow}. */
         this.REQUEST__WORKFLOWBUILDER_CREATE_WORKFLOWRUN = 'EVENT__WORKFLOWBUILDER_CREATE_WORKFLOWRUN';
         /** Request the Resources that are currently assigned to an InputPort. Takes {inputport: InputPort}. Returns [Resource]. */

--- a/src/js/Views/Master/Main/Resource/Collection/ViewResourceCollectionModalItemAssigned.js
+++ b/src/js/Views/Master/Main/Resource/Collection/ViewResourceCollectionModalItemAssigned.js
@@ -1,0 +1,57 @@
+import BaseViewCollectionItem from 'js/Views/Master/Main/BaseViewCollectionItem';
+import RODAN_EVENTS from 'js/Shared/RODAN_EVENTS';
+import Radio from 'backbone.radio';
+
+/**
+ * Resource item View for Collection in modal to display assigned resources.
+ */
+export default class ViewResourceCollectionModalItemAssigned extends BaseViewCollectionItem
+{
+///////////////////////////////////////////////////////////////////////////////////////
+// PUBLIC METHODS
+///////////////////////////////////////////////////////////////////////////////////////
+    /**
+     * Initializes the instance.
+     *
+     * @param {object} options Marionette.View options object; options.requestdata (object; data sent with requests), options.unassignrequest (object; when item becomes unassigned, this request is sent), options.moveup (object; when item is to be moved up, this request is sent), options.movedown (object; when item is to be moved down, this request is sent)
+     */
+    initialize(options)
+    {
+        this._requestData = options.requestdata;
+        this._unassignRequest = options.unassignrequest;
+        this._moveUp = options.moveup;
+        this._moveDown = options.movedown;
+    }
+
+///////////////////////////////////////////////////////////////////////////////////////
+// PRIVATE METHODS
+///////////////////////////////////////////////////////////////////////////////////////
+    _handleDoubleClick()
+    {
+        this._requestData.resource = this.model;
+        Radio.channel('rodan').request(this._unassignRequest, this._requestData);
+    }
+
+    _handleMoveUp()
+    {
+        this._requestData.resource = this.model;
+        Radio.channel('rodan').request(this._moveUp, this._requestData);
+    }
+
+    _handleMoveDown()
+    {
+        this._requestData.resource = this.model;
+        Radio.channel('rodan').request(this._moveDown, this._requestData);
+    }
+}
+ViewResourceCollectionModalItemAssigned.prototype.template = '#template-modal_resource_collection_item_assigned';
+ViewResourceCollectionModalItemAssigned.prototype.tagName = 'tr';
+ViewResourceCollectionModalItemAssigned.prototype.ui = {
+    moveUp: '.move-up',
+    moveDown: '.move-down',
+};
+ViewResourceCollectionModalItemAssigned.prototype.events = {
+    'dblclick': '_handleDoubleClick',
+    'click @ui.moveUp': '_handleMoveUp',
+    'click @ui.moveDown': '_handleMoveDown',
+};

--- a/templates/Views/Master/Main/Resource/Collection/template-modal_resource_collection.html
+++ b/templates/Views/Master/Main/Resource/Collection/template-modal_resource_collection.html
@@ -6,6 +6,8 @@
                 <th data-name="creator">Creator</th>
                 <th data-name="created">Created</th>
                 <th data-name="resource_type">Type</th>
+                <th></th>
+                <th></th>
             </tr>
         </thead>
         <tbody>

--- a/templates/Views/Master/Main/Resource/Collection/template-modal_resource_collection_item.html
+++ b/templates/Views/Master/Main/Resource/Collection/template-modal_resource_collection_item.html
@@ -2,3 +2,5 @@
 <td><%= creator %></td>
 <td><%= _.formatFromUTC(created) %></td>
 <td><%= resource_type_full.mimetype %></td>
+<td></td>
+<td></td>

--- a/templates/Views/Master/Main/Resource/Collection/template-modal_resource_collection_item_assigned.html
+++ b/templates/Views/Master/Main/Resource/Collection/template-modal_resource_collection_item_assigned.html
@@ -1,0 +1,10 @@
+<td><%= name %></td>
+<td><%= creator %></td>
+<td><%= _.formatFromUTC(created) %></td>
+<td><%= resource_type_full.mimetype %></td>
+<td>
+  <button type="button" class="move-up btn btn-success btn-xs">&uarr;</button>
+</td>
+<td>
+  <button type="button" class="move-down btn btn-success btn-xs">&darr;</button>
+</td>


### PR DESCRIPTION
## Gist

A workflow should accept the input of multiple resource collections that share the same length (greater than 1). The UI has to adapt correspondingly to support the development on server side (https://github.com/DDMAL/Rodan/pull/507).

## Changes

All changes are within the workflow builder pane.

- Remove resource assignment restriction on multi resource collections
- Display validation errors when workflowrun creation fails
- Add move up and down buttons to assigned resource collection view
  - A new view ViewResourceCollectionModalItemAssigned is added to display and handle the move up/down buttons.



## Proof

Videos: (password: rodan)

Adjust resource ordering: https://vimeo.com/382214288
Display validation errors: https://vimeo.com/382701031